### PR TITLE
Add logger setup to cookiecutter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Pycharm Properties
+.idea
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/{{cookiecutter.project_name}}-bdd/{{cookiecutter.project_name}}/data/logging.json
+++ b/{{cookiecutter.project_name}}-bdd/{{cookiecutter.project_name}}/data/logging.json
@@ -1,0 +1,41 @@
+{
+    "version": 1,
+    "disable_existing_loggers": false,
+    "formatters": {
+        "simple": {
+            "format": "%(asctime)s [%(levelname)s] %(name)s - %(message)s"
+        }
+    },
+
+    "handlers": {
+        "console": {
+            "class": "logging.StreamHandler",
+            "level": "DEBUG",
+            "formatter": "simple",
+            "stream": "ext://sys.stdout"
+        },
+
+        "debug_file_handler": {
+            "class": "logging.handlers.RotatingFileHandler",
+            "level": "DEBUG",
+            "formatter": "simple",
+            "filename": "log/{{cookiecutter.project_name}}.log",
+            "maxBytes": 10485760,
+            "backupCount": 10,
+            "encoding": "utf8"
+        }
+    },
+
+    "loggers": {
+        "warsawbdd": {
+            "level": "DEBUG",
+            "handlers": ["debug_file_handler"],
+            "propagate": "no"
+        }
+    },
+
+    "root": {
+        "level": "DEBUG",
+        "handlers": []
+    }
+}

--- a/{{cookiecutter.project_name}}-bdd/{{cookiecutter.project_name}}/features/environment.py
+++ b/{{cookiecutter.project_name}}-bdd/{{cookiecutter.project_name}}/features/environment.py
@@ -1,16 +1,24 @@
 """Hooks file."""
 from behave.tag_matcher import ActiveTagMatcher
 from ipdb import post_mortem
-
+from json import load
+from os import makedirs
+from os.path import isdir
+from logging import getLogger, config
+from {{cookiecutter.project_name}}.helpers import constants
 
 active_tag_value_provider = {
     "config_0": False
 }
 
+logger = None
 active_tag_matcher = ActiveTagMatcher(active_tag_value_provider)
 
 
 def before_all(context):
+
+    setup_logger()
+
     userdata = context.config.userdata
     context.config_0 = userdata.get('config_0', 'False')
 
@@ -47,3 +55,14 @@ def after_feature(context, feature):
 
 def after_all(context):
     pass
+
+def setup_logger():
+    global logger
+    if not isdir(constants.LOG_FILE_DIR):
+        makedirs(constants.LOG_FILE_DIR)
+
+    with open(constants.LOGGER_CONFIG, 'rt') as f:
+        options = load(f)
+
+    config.dictConfig(options)
+    logger = getLogger(__name__)

--- a/{{cookiecutter.project_name}}-bdd/{{cookiecutter.project_name}}/helpers/constants.py
+++ b/{{cookiecutter.project_name}}-bdd/{{cookiecutter.project_name}}/helpers/constants.py
@@ -1,3 +1,10 @@
 """When you write your constants to help you."""
 
+from os import getcwd
+from os.path import join
+
 exe_path = r'C:\\hello.exe'
+
+PATH = getcwd()
+LOG_FILE_DIR = join(PATH, "log")
+LOGGER_CONFIG = join(PATH, "{{cookiecutter.project_name}}", "data", "logging.json")


### PR DESCRIPTION
Including a function to setup the logger when `before_all` is called.
You think that it's ok to keep this function on "environment.py"? I didn't want to create a separated file just to set up the logger.

❤️ 